### PR TITLE
Remove production environment variable from Netlify configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,6 @@
 [build]
   command = "npm run build"
   publish = "out"
-  environment = { NODE_ENV = "production" }
 
 [build.environment]
   NPM_FLAGS = "--prefer-offline --no-audit --progress=false"


### PR DESCRIPTION
Eliminate the production environment variable from the Netlify configuration to streamline the build process.