### PR TITLE
Update Netlify configuration for publishing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = "npm run build"
-  publish = "out"
+  publish = ".next"
 
 [build.environment]
   NPM_FLAGS = "--prefer-offline --no-audit --progress=false"


### PR DESCRIPTION
Change the Netlify configuration to publish from the `.next` directory instead of the `out` directory.