### PR TITLE
Add file validation for PDF uploads in WriteStoryForm

### DIFF
--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://artformemories.com/apple-icon.png</loc><lastmod>2025-05-15T16:59:01.400Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://artformemories.com/icon0.svg</loc><lastmod>2025-05-15T16:59:01.411Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://artformemories.com/icon1.png</loc><lastmod>2025-05-15T16:59:01.411Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://artformemories.com/manifest.json</loc><lastmod>2025-05-15T16:59:01.411Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://artformemories.com/preserved-memories</loc><lastmod>2025-05-15T16:59:01.411Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://artformemories.com/about-us</loc><lastmod>2025-05-15T16:59:01.411Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://artformemories.com/stories/written</loc><lastmod>2025-05-15T16:59:01.411Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://artformemories.com/stories</loc><lastmod>2025-05-15T16:59:01.411Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://artformemories.com/contact-us</loc><lastmod>2025-05-15T16:59:01.411Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://artformemories.com/memory</loc><lastmod>2025-05-15T16:59:01.411Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://artformemories.com/stories/illustrated</loc><lastmod>2025-05-15T16:59:01.412Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://artformemories.com</loc><lastmod>2025-05-15T16:59:01.412Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://artformemories.com/one-day-in-100-days</loc><lastmod>2025-05-15T16:59:01.412Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://artformemories.com/manifest.json</loc><lastmod>2025-05-20T07:35:21.904Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://artformemories.com/icon0.svg</loc><lastmod>2025-05-20T07:35:21.905Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://artformemories.com/icon1.png</loc><lastmod>2025-05-20T07:35:21.905Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://artformemories.com/apple-icon.png</loc><lastmod>2025-05-20T07:35:21.905Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://artformemories.com/preserved-memories</loc><lastmod>2025-05-20T07:35:21.905Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://artformemories.com/memory</loc><lastmod>2025-05-20T07:35:21.905Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://artformemories.com/stories/written</loc><lastmod>2025-05-20T07:35:21.905Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://artformemories.com/about-us</loc><lastmod>2025-05-20T07:35:21.905Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://artformemories.com/contact-us</loc><lastmod>2025-05-20T07:35:21.905Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://artformemories.com</loc><lastmod>2025-05-20T07:35:21.905Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://artformemories.com/stories</loc><lastmod>2025-05-20T07:35:21.905Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://artformemories.com/stories/illustrated</loc><lastmod>2025-05-20T07:35:21.905Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://artformemories.com/one-day-in-100-days</loc><lastmod>2025-05-20T07:35:21.905Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/components/forms/WriteStoryForm.tsx
+++ b/src/components/forms/WriteStoryForm.tsx
@@ -22,8 +22,20 @@ function WriteStoryForm({ currentStory }: { currentStory: Stories | null }) {
 
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
         if (e.target.files && e.target.files.length > 0) {
-            console.log(e.target.files[0])
-            setFormData({ ...formData, file: e.target.files[0] });
+            const file = e.target.files[0];
+
+            if (file.type !== "application/pdf") {
+                alert("Only PDF files are allowed.");
+                e.target.value = "";
+                return;
+            }
+            if (file.size > 4 * 1024 * 1024) {
+                alert("PDF file size must not exceed 4MB.");
+                e.target.value = "";
+                return;
+            }
+            
+            setFormData({ ...formData, file });
         }
     };
 


### PR DESCRIPTION
Implement validation to ensure only PDF files under 4MB can be uploaded in the WriteStoryForm component. Alerts notify users of invalid file types or sizes.